### PR TITLE
fix: text col index specified with no key length

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -139,7 +139,7 @@ class Install extends Migration
         $this->createIndex(
             null,
             '{{%communicator_changelogs}}',
-            'content',
+            'content(255)',
             false
         );
         // Additional commands depending on the db driver
@@ -171,7 +171,7 @@ class Install extends Migration
         $this->createIndex(
             null,
             '{{%communicator_globalwidgets}}',
-            'content',
+            'content(255)',
             false
         );
         // Additional commands depending on the db driver


### PR DESCRIPTION
When installing the plugin, it takes 2 attempts to install the plugin, as an error during index creation occurs during the Install migration:

- craft-communicator:1.0.2 
- Craft 3.5.15.1
- Yii 2.0.38
- mariadb:10.3

```
2021-04-19 15:30:56 [-][21][-][error][craft\db\MigrationManager::migrateUp] Failed to apply Install (time: 0.058s). Output:
    > create table {{%communicator_changelogs}} ... done (time: 0.014s)
    > create table {{%communicator_globalwidgets}} ... done (time: 0.017s)
    > create index craft_communicator_changelogs_date_idx on {{%communicator_changelogs}} (date) ... done (time: 0.010s)
    > create index craft_communicator_changelogs_format_idx on {{%communicator_changelogs}} (format) ... done (time: 0.007s)
    > create index craft_communicator_changelogs_version_idx on {{%communicator_changelogs}} (version) ... done (time: 0.006s)
    > create index craft_communicator_changelogs_content_idx on {{%communicator_changelogs}} (content) ...Exception: SQLSTATE[42000]: Syntax error or access violation: 1170 BLOB/TEXT column 'content' used in key specification without a key length
The SQL being executed was: ALTER TABLE `craft_communicator_changelogs` ADD INDEX `craft_communicator_changelogs_content_idx` (`content`) (/var/www/html/vendor/yiisoft/yii2/db/Schema.php:677)
```


This fix hasn't been tested on other combinations of the components described above.